### PR TITLE
Bugfix/unexpected result with flowed formatted emails

### DIFF
--- a/lib/elixir_email_reply_parser/parser.ex
+++ b/lib/elixir_email_reply_parser/parser.ex
@@ -34,9 +34,9 @@ defmodule ElixirEmailReplyParser.Parser do
   @spec handle_multiline(String.t) :: String.t
   defp handle_multiline(s) do
     Enum.reduce([
-          ~R/(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)/s,
+          ~R/(On(?:(?!On|wrote:)(.|\s))*?wrote:)/s,
           ~R/(schrieb\sam\s(.+?)um\s(.+?):)/s,
-          ~R/(Am\s(.+?)um\s(.+?)schrieb\s(.+?):)/s ],
+          ~R/(Am\s(.+?)um\s(.+?)schrieb\s(.+?):)/s],
         s,
         &remove_newlines_if_matched/2)
   end

--- a/test/elixir_email_reply_parser_test.exs
+++ b/test/elixir_email_reply_parser_test.exs
@@ -425,6 +425,11 @@ I am currently using the Java HTTP API.\n"
     assert ElixirEmailReplyParser.parse_reply(body) == "test 2 this should list second\n\nand have spaces\n\nand retain this formatting\n\n\n   - how about bullets\n   - and another"
   end
 
+  test "consecutive emails flowed formatted" do
+    body = get_email_content("consecutive_emails_flowed_formatted")
+    assert ElixirEmailReplyParser.parse_reply(body) == "another response"
+  end
+
   test "ruby_test_one_is_not_on" do
     email_message = get_email('email_one_is_not_on')
     %ElixirEmailReplyParser.EmailMessage{fragments: fragments} = email_message

--- a/test/emails/consecutive_emails_flowed_formatted.txt
+++ b/test/emails/consecutive_emails_flowed_formatted.txt
@@ -1,0 +1,14 @@
+another response
+
+On 8 November 2017 at 23:08, Kiyoaki Menager <
+kiyoaki.menager@hellogustav.com> wrote:
+
+> response
+>
+> On 8 November 2017 at 23:06, kiyo l'employer via Gustav <
+> no-reply@msgstest.gustav.careers> wrote:
+>
+>> Intro
+>
+>
+>


### PR DESCRIPTION
This PR addresses issue with parsing of emails that follows the content-type's format `flowed`.

**Current unexpected result:**

```
"Body of the second message\n\nOn 8 November 2017 at 23:06, Kiyoaki Menager <\nkiyoaki.menager@hellogustav.com> wrote:"
```

**Expected result:**

```
"Body of the second message"
```

---

This happens because the flowed format breaks lines that exceeds 78 characters resulting in broken email reply headers.

In the function `handle_multiline\1` (responsible of removing multilines in general), the regex  responsible of matching _reply headers_ would not match those containing newlines; preventing the function to fulfil its purpose: removing newlines from reply headers.

The new regex handles reply headers with newlines and will match the shortest headers possible:

For the following string:

```elixir
"On this beautiful morning, On DATE, NAME <\nEMAIL> wrote: I wrote this poem"
```

The regex would match:

```elixir
"On DATE, NAME <\nEMAIL> wrote:"
```

And `handle_multiline\1` would spit:
```
"On this beautiful morning, On DATE, NAME <EMAIL> wrote: I wrote this poem"
```